### PR TITLE
fix: Copybooks mismatch in cache #1328

### DIFF
--- a/server/src/main/java/org/eclipse/lsp/cobol/core/preprocessor/CopybookHierarchy.java
+++ b/server/src/main/java/org/eclipse/lsp/cobol/core/preprocessor/CopybookHierarchy.java
@@ -20,6 +20,7 @@ import lombok.Setter;
 import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.lsp.cobol.core.model.CopyStatementModifier;
 import org.eclipse.lsp.cobol.core.model.CopybookUsage;
+import org.eclipse.lsp.cobol.core.model.Locality;
 import org.eclipse.lsp.cobol.core.preprocessor.delegates.copybooks.analysis.CopybookName;
 
 import java.util.*;
@@ -73,6 +74,12 @@ public class CopybookHierarchy {
     recursiveReplaceStmtStack.pollFirst();
   }
 
+  /** @return root document URI */
+  public Optional<String> getRootDocumentUri() {
+    return Optional.ofNullable(copybookStack.peekLast())
+            .map(CopybookUsage::getLocality)
+            .map(Locality::getUri);
+  }
   /**
    * Add a pattern for replacing from COPY statement
    *

--- a/server/src/main/java/org/eclipse/lsp/cobol/core/preprocessor/delegates/copybooks/analysis/AbstractCopybookAnalysis.java
+++ b/server/src/main/java/org/eclipse/lsp/cobol/core/preprocessor/delegates/copybooks/analysis/AbstractCopybookAnalysis.java
@@ -212,21 +212,24 @@ abstract class AbstractCopybookAnalysis implements CopybookAnalysis {
   }
 
   protected ResultWithErrors<CopybookModel> getCopyBookContent(
-      CopybookMetaData metaData, CopybookHierarchy hierarchy) {
-    if (metaData.getCopybookName().getDisplayName().isEmpty())
-      return emptyModel(metaData.getCopybookName(), ImmutableList.of());
+      CopybookMetaData copybookMetaData, CopybookHierarchy hierarchy) {
+    if (copybookMetaData.getCopybookName().getDisplayName().isEmpty())
+      return emptyModel(copybookMetaData.getCopybookName(), ImmutableList.of());
 
-    if (hierarchy.hasRecursion(metaData.getCopybookName()))
+    if (hierarchy.hasRecursion(copybookMetaData.getCopybookName()))
       return emptyModel(
-          metaData.getCopybookName(), hierarchy.mapCopybooks(this::reportRecursiveCopybook));
+          copybookMetaData.getCopybookName(), hierarchy.mapCopybooks(this::reportRecursiveCopybook));
 
     CopybookModel copybook =
         copybookService.resolve(
-            metaData.getCopybookName(), metaData.getDocumentUri(), metaData.getConfig());
+            copybookMetaData.getCopybookName(),
+                hierarchy.getRootDocumentUri().orElse(copybookMetaData.getDocumentUri()),
+                copybookMetaData.getDocumentUri(),
+                copybookMetaData.getConfig());
 
     if (copybook.getContent() == null) {
       return emptyModel(
-          metaData.getCopybookName(), ImmutableList.of(reportMissingCopybooks(metaData)));
+          copybookMetaData.getCopybookName(), ImmutableList.of(reportMissingCopybooks(copybookMetaData)));
     }
 
     return new ResultWithErrors<>(copybook, ImmutableList.of());

--- a/server/src/main/java/org/eclipse/lsp/cobol/core/preprocessor/delegates/copybooks/analysis/CopybookName.java
+++ b/server/src/main/java/org/eclipse/lsp/cobol/core/preprocessor/delegates/copybooks/analysis/CopybookName.java
@@ -36,13 +36,4 @@ public class CopybookName {
     this.dialectType = dialectType;
     this.qualifiedName = displayName;
   }
-
-  /**
-   * Creates a processing copybook name using a name and a dialect type
-   *
-   * @return a processing copybook name
-   */
-  public String getProcessingName() {
-    return String.format("%s#%s", qualifiedName, dialectType);
-  }
 }

--- a/server/src/main/java/org/eclipse/lsp/cobol/service/copybooks/CopybookService.java
+++ b/server/src/main/java/org/eclipse/lsp/cobol/service/copybooks/CopybookService.java
@@ -31,19 +31,22 @@ public interface CopybookService {
    * Retrieve and return the copybook by its name.
    *
    * @param copybookName - the name of the copybook to be retrieved
+   * @param programDocumentUri - the currently processing program document
    * @param documentUri - the currently processing document that contains the copy statement
    * @param copybookConfig - contains config info like: copybook processing mode, target backend sql server
    * @return a CopybookModel that contains copybook name, its URI and the content
    */
   CopybookModel resolve(
       @NonNull CopybookName copybookName,
+      @NonNull String programDocumentUri,
       @NonNull String documentUri,
       @NonNull CopybookConfig copybookConfig);
 
   /**
-   * Store the copybookModel in cache.
+   * Store the copybookModel in cache. Copybook depends on a document from where it is imported.
    *
    * @param copybookModel the copybook model
+   * @param documentUri is a URI of a document from where the copybook is imported.
    */
-  void store(CopybookModel copybookModel);
+  void store(CopybookModel copybookModel, String documentUri);
 }

--- a/server/src/main/java/org/eclipse/lsp/cobol/service/copybooks/CopybookServiceImpl.java
+++ b/server/src/main/java/org/eclipse/lsp/cobol/service/copybooks/CopybookServiceImpl.java
@@ -101,6 +101,7 @@ public class CopybookServiceImpl implements CopybookService {
    * each other.
    *
    * @param copybookName - the name of the copybook to be retrieved
+   * @param programDocumentUri - the currently processing program document
    * @param documentUri - the currently processing document that contains the copy statement
    * @param copybookConfig - contains config info like: copybook processing mode, target backend sql
    *     server
@@ -108,12 +109,12 @@ public class CopybookServiceImpl implements CopybookService {
    */
   public CopybookModel resolve(
       @NonNull CopybookName copybookName,
+      @NonNull String programDocumentUri,
       @NonNull String documentUri,
       @NonNull CopybookConfig copybookConfig) {
     try {
-      return copybookCache.get(
-          copybookName.getProcessingName(),
-          () -> resolveSync(copybookName, documentUri, copybookConfig));
+      String cacheKay = makeCopybookCacheKay(copybookName, programDocumentUri);
+      return copybookCache.get(cacheKay, () -> resolveSync(copybookName, documentUri, copybookConfig));
     } catch (ExecutionException | UncheckedExecutionException | ExecutionError e) {
       LOG.error("Can't resolve copybook '{}'.", copybookName, e);
       return new CopybookModel(copybookName, null, null);
@@ -121,8 +122,9 @@ public class CopybookServiceImpl implements CopybookService {
   }
 
   @Override
-  public void store(CopybookModel copybookModel) {
-    copybookCache.put(copybookModel.getCopybookName().getProcessingName(), copybookModel);
+  public void store(CopybookModel copybookModel, String documentUri) {
+    String cacheKay = makeCopybookCacheKay(copybookModel.getCopybookName(), documentUri);
+    copybookCache.put(cacheKay, copybookModel);
   }
 
   private CopybookModel resolveSync(
@@ -264,5 +266,9 @@ public class CopybookServiceImpl implements CopybookService {
 
   private String getUserInteractionType(CopybookProcessingMode copybookProcessingMode) {
     return copybookProcessingMode.userInteraction ? VERBOSE.label : QUIET.label;
+  }
+
+  private static String makeCopybookCacheKay(CopybookName copybookName, String documentUri) {
+    return String.format("%s#%s#%s", copybookName.getQualifiedName(), copybookName.getDialectType(), documentUri);
   }
 }

--- a/server/src/test/java/org/eclipse/lsp/cobol/service/copybooks/CopybookServiceTest.java
+++ b/server/src/test/java/org/eclipse/lsp/cobol/service/copybooks/CopybookServiceTest.java
@@ -105,7 +105,7 @@ class CopybookServiceTest {
   void testRequestWhileCopybookAnalysisActiveProcessed() {
     CopybookName copybookName = new CopybookName(VALID_CPY_NAME, DialectType.COBOL.name());
     CopybookService copybookService = createCopybookService();
-    CopybookModel copybookModel = copybookService.resolve(copybookName, DOCUMENT_URI, cpyConfig);
+    CopybookModel copybookModel = copybookService.resolve(copybookName, DOCUMENT_URI, DOCUMENT_URI, cpyConfig);
 
     assertEquals(new CopybookModel(copybookName, VALID_CPY_URI, CONTENT), copybookModel);
     verify(files).getNameFromURI(DOCUMENT_URI);
@@ -122,7 +122,7 @@ class CopybookServiceTest {
     CopybookName copybookName = new CopybookName(VALID_CPY_NAME, DialectType.COBOL.name());
     CopybookService copybookService = createCopybookService();
     when(files.getPathFromURI(VALID_CPY_URI)).thenReturn(null);
-    CopybookModel copybookModel = copybookService.resolve(copybookName, DOCUMENT_URI, cpyConfig);
+    CopybookModel copybookModel = copybookService.resolve(copybookName, DOCUMENT_URI, DOCUMENT_URI, cpyConfig);
 
     assertEquals(new CopybookModel(copybookName, null, null), copybookModel);
     verify(files).getNameFromURI(DOCUMENT_URI);
@@ -138,7 +138,7 @@ class CopybookServiceTest {
     CopybookName copybookName = new CopybookName(INVALID_CPY_NAME, DialectType.COBOL.name());
     CopybookService copybookService = createCopybookService();
     CopybookModel copybookModel =
-        copybookService.resolve(copybookName, DOCUMENT_URI, cpyConfig);
+        copybookService.resolve(copybookName, DOCUMENT_URI, DOCUMENT_URI, cpyConfig);
 
     assertEquals(new CopybookModel(copybookName, null, null), copybookModel);
     verify(files).getNameFromURI(DOCUMENT_URI);
@@ -153,9 +153,9 @@ class CopybookServiceTest {
     CopybookName copybookName = new CopybookName(VALID_CPY_NAME, DialectType.COBOL.name());
     CopybookService copybookService = createCopybookService();
     CopybookModel copybookModelEnabled =
-        copybookService.resolve(copybookName, DOCUMENT_URI, cpyConfig);
+        copybookService.resolve(copybookName, DOCUMENT_URI, DOCUMENT_URI, cpyConfig);
     CopybookModel copybookModelSkipped =
-        copybookService.resolve(copybookName, DOCUMENT_URI, new CopybookConfig(SKIP, DB2_SERVER, ImmutableList.of()));
+        copybookService.resolve(copybookName, DOCUMENT_URI, DOCUMENT_URI, new CopybookConfig(SKIP, DB2_SERVER, ImmutableList.of()));
 
     verify(files, times(1)).getContentByPath(cpyPath);
     verify(files, times(1)).getNameFromURI(DOCUMENT_URI);
@@ -174,12 +174,12 @@ class CopybookServiceTest {
     CopybookName copybookName = new CopybookName(VALID_CPY_NAME, DialectType.COBOL.name());
     CopybookService copybookService = createCopybookService();
 
-    CopybookModel copybookModel = copybookService.resolve(copybookName, DOCUMENT_URI, cpyConfig);
+    CopybookModel copybookModel = copybookService.resolve(copybookName, DOCUMENT_URI, DOCUMENT_URI, cpyConfig);
     assertEquals(new CopybookModel(copybookName, VALID_CPY_URI, CONTENT), copybookModel);
 
     copybookService.invalidateCache();
 
-    copybookModel = copybookService.resolve(copybookName, DOCUMENT_URI, cpyConfig);
+    copybookModel = copybookService.resolve(copybookName, DOCUMENT_URI, DOCUMENT_URI, cpyConfig);
     assertEquals(new CopybookModel(copybookName, VALID_CPY_URI, CONTENT), copybookModel);
 
     verify(files, times(2)).getContentByPath(cpyPath);
@@ -195,7 +195,7 @@ class CopybookServiceTest {
     CopybookName copybookName = new CopybookName(VALID_CPY_NAME, DialectType.COBOL.name());
     CopybookService copybookService = createCopybookService();
     when(settingsService.getConfiguration(any())).thenReturn(completedFuture(null));
-    CopybookModel copybookModel = copybookService.resolve(copybookName, DOCUMENT_URI, cpyConfig);
+    CopybookModel copybookModel = copybookService.resolve(copybookName, DOCUMENT_URI, DOCUMENT_URI, cpyConfig);
 
     assertEquals(new CopybookModel(copybookName, null, null), copybookModel);
     verify(files, times(1)).getNameFromURI(DOCUMENT_URI);
@@ -217,11 +217,11 @@ class CopybookServiceTest {
         .thenReturn(supplyAsync(() -> singletonList(new JsonPrimitive(""))));
 
     // First document parsed
-    CopybookModel invalidCpy = copybookService.resolve(new CopybookName(INVALID_CPY_NAME, DialectType.COBOL.name()), DOCUMENT_URI, cpyConfig);
-    CopybookModel validCpy = copybookService.resolve(new CopybookName(VALID_CPY_NAME, DialectType.COBOL.name()), DOCUMENT_URI, cpyConfig);
+    CopybookModel invalidCpy = copybookService.resolve(new CopybookName(INVALID_CPY_NAME, DialectType.COBOL.name()), DOCUMENT_URI, DOCUMENT_URI, cpyConfig);
+    CopybookModel validCpy = copybookService.resolve(new CopybookName(VALID_CPY_NAME, DialectType.COBOL.name()), DOCUMENT_URI, DOCUMENT_URI, cpyConfig);
     // Second document parsed
     CopybookModel invalidCpy2 =
-        copybookService.resolve(new CopybookName(INVALID_2_CPY_NAME, DialectType.COBOL.name()), DOCUMENT_2_URI, cpyConfig);
+        copybookService.resolve(new CopybookName(INVALID_2_CPY_NAME, DialectType.COBOL.name()), DOCUMENT_2_URI, DOCUMENT_2_URI, cpyConfig);
 
     // Check that all copybook models are correct
     assertEquals(new CopybookModel(new CopybookName(VALID_CPY_NAME, DialectType.COBOL.name()), VALID_CPY_URI, CONTENT), validCpy);
@@ -266,7 +266,7 @@ class CopybookServiceTest {
     CopybookServiceImpl copybookService = createCopybookService();
 
     Assertions.assertThrows(
-        IllegalArgumentException.class, () -> copybookService.resolve(new CopybookName(SQLCA, DialectType.COBOL.name()), DOCUMENT_URI, null));
+        IllegalArgumentException.class, () -> copybookService.resolve(new CopybookName(SQLCA, DialectType.COBOL.name()), DOCUMENT_URI, DOCUMENT_URI, null));
   }
 
   /**
@@ -282,7 +282,7 @@ class CopybookServiceTest {
     when(files.getNameFromURI(DOCUMENT_3_URI)).thenReturn("document2");
     when(settingsService.getConfiguration("copybook-resolve", "document2", SQLCA, DialectType.COBOL.name()))
         .thenReturn(supplyAsync(() -> singletonList(new JsonPrimitive(""))));
-    CopybookModel cpy = copybookService.resolve(copybookName, DOCUMENT_3_URI, cpyConfig);
+    CopybookModel cpy = copybookService.resolve(copybookName, DOCUMENT_3_URI, DOCUMENT_3_URI, cpyConfig);
 
     assertEquals(new CopybookModel(copybookName, DOCUMENT_3_URI, null), cpy);
   }
@@ -298,7 +298,7 @@ class CopybookServiceTest {
     when(settingsService.getConfiguration("copybook-resolve", "document2", SQLCA, DialectType.COBOL.name()))
         .thenReturn(supplyAsync(() -> singletonList(new JsonPrimitive(""))));
     CopybookModel cpy =
-        copybookService.resolve(copybookName, DOCUMENT_URI, new CopybookConfig(ENABLED, DATACOM_SERVER, ImmutableList.of()));
+        copybookService.resolve(copybookName, DOCUMENT_URI, DOCUMENT_URI, new CopybookConfig(ENABLED, DATACOM_SERVER, ImmutableList.of()));
 
     assertEquals(
         new CopybookModel(copybookName, "implicit:///implicitCopybooks/SQLCA_DATACOM.cpy", null), cpy);
@@ -316,8 +316,8 @@ class CopybookServiceTest {
         .thenReturn(supplyAsync(() -> singletonList(new JsonPrimitive(""))));
 
     assertEquals(
-        copybookService.resolve(copybookName, DOCUMENT_URI, new CopybookConfig(ENABLED, DATACOM_SERVER, ImmutableList.of())),
-        copybookService.resolve(copybookName, DOCUMENT_URI, new CopybookConfig(ENABLED, DB2_SERVER, ImmutableList.of())));
+        copybookService.resolve(copybookName, DOCUMENT_URI, DOCUMENT_URI, new CopybookConfig(ENABLED, DATACOM_SERVER, ImmutableList.of())),
+        copybookService.resolve(copybookName, DOCUMENT_URI, DOCUMENT_URI, new CopybookConfig(ENABLED, DB2_SERVER, ImmutableList.of())));
   }
 
   /**
@@ -333,7 +333,7 @@ class CopybookServiceTest {
     when(files.getNameFromURI(DOCUMENT_3_URI)).thenReturn("document2");
     when(settingsService.getConfiguration("copybook-resolve", "document2", DFHEIBLC, DialectType.COBOL.name()))
         .thenReturn(supplyAsync(() -> singletonList(new JsonPrimitive(""))));
-    CopybookModel cpy = copybookService.resolve(copybookName, DOCUMENT_3_URI, cpyConfig);
+    CopybookModel cpy = copybookService.resolve(copybookName, DOCUMENT_3_URI, DOCUMENT_3_URI, cpyConfig);
 
     assertEquals(
         new CopybookModel(copybookName, "implicit:///implicitCopybooks/DFHEIBLC.cpy", null), cpy);
@@ -359,10 +359,10 @@ class CopybookServiceTest {
     when(settingsService.getConfiguration("copybook-resolve", "document", PARENT_CPY_NAME, DialectType.COBOL.name()))
         .thenReturn(supplyAsync(() -> singletonList(new JsonPrimitive(PARENT_CPY_URI))));
 
-    CopybookModel invalidCpy = copybookService.resolve(new CopybookName(INVALID_CPY_NAME, DialectType.COBOL.name()), DOCUMENT_URI, cpyConfig);
-    CopybookModel parentCpy = copybookService.resolve(new CopybookName(PARENT_CPY_NAME, DialectType.COBOL.name()), DOCUMENT_URI, cpyConfig);
+    CopybookModel invalidCpy = copybookService.resolve(new CopybookName(INVALID_CPY_NAME, DialectType.COBOL.name()), DOCUMENT_URI, DOCUMENT_URI, cpyConfig);
+    CopybookModel parentCpy = copybookService.resolve(new CopybookName(PARENT_CPY_NAME, DialectType.COBOL.name()), DOCUMENT_URI, DOCUMENT_URI, cpyConfig);
     // Nested copybook declaration
-    CopybookModel nestedCpy = copybookService.resolve(new CopybookName(NESTED_CPY_NAME, DialectType.COBOL.name()), PARENT_CPY_URI, cpyConfig);
+    CopybookModel nestedCpy = copybookService.resolve(new CopybookName(NESTED_CPY_NAME, DialectType.COBOL.name()), DOCUMENT_URI, PARENT_CPY_URI, cpyConfig);
 
     // Check that all copybook models are correct
     assertEquals(new CopybookModel(new CopybookName(INVALID_CPY_NAME, DialectType.COBOL.name()), null, null), invalidCpy);
@@ -396,7 +396,7 @@ class CopybookServiceTest {
                   throw new NullPointerException();
                 }));
     CopybookService copybookService = createCopybookService();
-    CopybookModel copybookModel = copybookService.resolve(copybookName, DOCUMENT_URI, cpyConfig);
+    CopybookModel copybookModel = copybookService.resolve(copybookName, DOCUMENT_URI, DOCUMENT_URI, cpyConfig);
 
     assertEquals(new CopybookModel(copybookName, null, null), copybookModel);
   }
@@ -407,7 +407,7 @@ class CopybookServiceTest {
     when(settingsService.getConfiguration("copybook-resolve", "document", VALID_CPY_NAME, DialectType.COBOL.name()))
         .thenThrow(new RuntimeException("Something is wrong"));
     CopybookService copybookService = createCopybookService();
-    CopybookModel copybookModel = copybookService.resolve(copybookName, DOCUMENT_URI, cpyConfig);
+    CopybookModel copybookModel = copybookService.resolve(copybookName, DOCUMENT_URI, DOCUMENT_URI, cpyConfig);
 
     assertEquals(new CopybookModel(copybookName, null, null), copybookModel);
   }
@@ -420,7 +420,7 @@ class CopybookServiceTest {
         .thenReturn(supplyAsync(() -> ImmutableList.of(new JsonPrimitive(""))));
     final CopybookModel model =
         copybookService.resolve(
-            new CopybookName(copybookName, DialectType.COBOL.name()), DOCUMENT_URI, new CopybookConfig(ENABLED, DB2_SERVER, ImmutableList.of()));
+            new CopybookName(copybookName, DialectType.COBOL.name()), DOCUMENT_URI, DOCUMENT_URI, new CopybookConfig(ENABLED, DB2_SERVER, ImmutableList.of()));
 
     assertEquals("implicit:///implicitCopybooks/SQLCA_DB2.cpy", model.getUri());
     verify(settingsService, times(1))
@@ -443,7 +443,7 @@ class CopybookServiceTest {
     // Assert the copybook was resolved from the workspace
     final CopybookModel model =
         copybookService.resolve(
-            new CopybookName(copybookName, DialectType.COBOL.name()), DOCUMENT_URI, new CopybookConfig(ENABLED, DB2_SERVER, ImmutableList.of()));
+            new CopybookName(copybookName, DialectType.COBOL.name()), DOCUMENT_URI, DOCUMENT_URI, new CopybookConfig(ENABLED, DB2_SERVER, ImmutableList.of()));
 
     // Assert the copybook was resolved from the workspace
     assertEquals(copybookUri, model.getUri());

--- a/server/src/test/java/org/eclipse/lsp/cobol/usecases/engine/AnnotatedDocumentCleaning.java
+++ b/server/src/test/java/org/eclipse/lsp/cobol/usecases/engine/AnnotatedDocumentCleaning.java
@@ -20,7 +20,6 @@ import lombok.experimental.UtilityClass;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
 import org.eclipse.lsp.cobol.core.preprocessor.delegates.copybooks.DialectType;
-import org.eclipse.lsp.cobol.core.preprocessor.delegates.copybooks.analysis.CopybookName;
 import org.eclipse.lsp.cobol.positive.CobolText;
 import org.eclipse.lsp.cobol.service.copybooks.PredefinedCopybooks;
 import org.eclipse.lsp.cobol.service.SQLBackend;
@@ -66,7 +65,8 @@ class AnnotatedDocumentCleaning {
     List<String> copybookNames =
         explicitCopybooks.stream()
             .map(CobolText::getCopybookName)
-            .map(CopybookName::getProcessingName)
+            .map(cbName -> String.format("%s#%s#%s",
+                    cbName.getQualifiedName(), cbName.getDialectType(), DOCUMENT_URI))
             .collect(toList());
     TestData testData =
         processDocument(

--- a/server/src/test/java/org/eclipse/lsp/cobol/usecases/engine/UseCaseUtils.java
+++ b/server/src/test/java/org/eclipse/lsp/cobol/usecases/engine/UseCaseUtils.java
@@ -113,11 +113,11 @@ public class UseCaseUtils {
 
     CopybookService copybookService = injector.getInstance(CopybookService.class);
     PredefinedCopybookUtils.loadPredefinedCopybooks(useCase.getSqlBackend(), useCase.getCopybooks(), useCase.getAnalysisConfig().getCopybookConfig().getPredefinedLabels())
-        .forEach(copybookService::store);
+        .forEach(copybookModel -> copybookService.store(copybookModel, useCase.fileName));
 
     useCase.getCopybooks().stream()
         .map(UseCaseUtils::toCopybookModel)
-        .forEach(copybookService::store);
+        .forEach(copybookModel -> copybookService.store(copybookModel, useCase.fileName));
 
     SubroutineService subroutines = injector.getInstance(SubroutineService.class);
     useCase.getSubroutines().forEach(name -> subroutines.store(name, "URI:" + name));


### PR DESCRIPTION
I've added a documentUri of a program to copybook cache id to distinguish copybooks based on a program it is used in.